### PR TITLE
Obtain golang/protobuf/protoc-gen-go with go get.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ PROTO_INCLUDE_PATHS += .
 		$(@D)/*.proto
 
 artifacts/protobuf/bin/protoc-gen-go: go.mod
-	GOBIN="$(MF_PROJECT_ROOT)/artifacts/protobuf/bin" go install github.com/golang/protobuf/protoc-gen-go
+	GOBIN="$(MF_PROJECT_ROOT)/artifacts/protobuf/bin" go get github.com/golang/protobuf/protoc-gen-go


### PR DESCRIPTION
This proposed change aims at replacing `go install` command with `go get` when downloading `protoc-gen-go` binary to the `artifacts/protobuf/bin` directory in the repository. The change is necessitated by the fact that `go install` no longer seems to observer `go.mod` package versions and acts more or less like an global binary installation tool.