### PR TITLE
Search through go.mod for protobuf packages in order of preference.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ PROTO_INCLUDE_PATHS += .
 		$(@D)/*.proto
 
 artifacts/protobuf/bin/protoc-gen-go: go.mod
-	GOBIN="$(MF_PROJECT_ROOT)/artifacts/protobuf/bin" go install github.com/golang/protobuf/protoc-gen-go
+	$(MF_ROOT)/pkg/protobuf/v1/bin/install-protoc-gen-go "$(@D)"

--- a/bin/install-protoc-gen-go
+++ b/bin/install-protoc-gen-go
@@ -19,8 +19,7 @@ for entry in "${packages[@]}"; do
     module="${pair[0]}"
     package="${pair[1]}"
 
-    version="$(go list -f '{{.Version}}' -m "$module" 2> /dev/null)"
-    if [[ -n "$version" ]]; then
+    if version="$(go list -f '{{.Version}}' -m "$module" 2> /dev/null)"; then
         echo "installing $package@version"
         GOBIN="$1" go get "$package@$version"
         exit

--- a/bin/install-protoc-gen-go
+++ b/bin/install-protoc-gen-go
@@ -19,7 +19,7 @@ for entry in "${packages[@]}"; do
     module="${pair[0]}"
     package="${pair[1]}"
 
-    version="$(go list -f '{{.Version}}' -m "$module")"
+    version="$(go list -f '{{.Version}}' -m "$module" 2> /dev/null)"
     if [[ -n "$version" ]]; then
         echo "installing $package@version"
         GOBIN="$1" go get "$package@$version"

--- a/bin/install-protoc-gen-go
+++ b/bin/install-protoc-gen-go
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# packages is a preferentially ordered list of packages that provide the
+# protoc-gen-go binary.
+#
+# Each entry is a pair of module path to look for in go.mod, and the
+# "protoc-gen-go" package to install if that module is found.
+packages=(
+    'google.golang.org/protobuf google.golang.org/protobuf/cmd/protoc-gen-go'
+    'github.com/golang/protobuf github.com/golang/protobuf/protoc-gen-go'
+)
+
+echo "installing protoc-gen-go"
+
+# look in go.mod for each of the desired packages
+for entry in "${packages[@]}"; do
+    pair=($entry)
+    module="${pair[0]}"
+    package="${pair[1]}"
+
+    version="$(go list -f '{{.Version}}' -m "$module")"
+    if [[ -n "$version" ]]; then
+        echo "installing $package@version"
+        GOBIN="$1" go get "$package@$version"
+        exit
+    fi
+done
+
+# we couldn't find anything in go.mod, so install our top preference
+for entry in ${packages[@]}; do
+    pair=($entry)
+    module="${pair[0]}"
+    package="${pair[1]}"
+
+    echo "installing $package@version"
+    GOBIN="$1" go get "$package@$version"
+    exit
+done


### PR DESCRIPTION
This PR updates the makefile to support the `protoc-gen-go` binary obtained from the new "version 2 (sort of)" protobuf package at `google.golang.org/protobuf". 
