### PR TITLE
Fix protobuf binary installation script.

### DIFF
--- a/bin/install-protoc-gen-go
+++ b/bin/install-protoc-gen-go
@@ -25,7 +25,7 @@ for entry in "${packages[@]}"; do
 done
 
 # we couldn't find anything in go.mod, so install our top preference
-for entry in ${packages[@]}; do
+for entry in "${packages[@]}"; do
     pair=($entry)
     module="${pair[0]}"
     package="${pair[1]}"

--- a/bin/install-protoc-gen-go
+++ b/bin/install-protoc-gen-go
@@ -29,6 +29,8 @@ for entry in "${packages[@]}"; do
     pair=($entry)
     module="${pair[0]}"
     package="${pair[1]}"
+    # default to the latest version of the package
+    version="latest"
 
     echo "installing $package@$version by default"
     GOBIN="$1" go get "$package@$version"


### PR DESCRIPTION
This PR fixes the PB binary installation script, namely the part that is dealing with the installation when no protobuf library versions are specified in `go.mod` file.