### PR TITLE
Pre-download Golang modules to import errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,5 +72,6 @@ artifacts/protobuf/args/common:
 	echo $(addprefix --proto_path=,$(PROTO_INCLUDE_PATHS)) > $@
 
 artifacts/protobuf/args/go: go.mod
+	go mod download all
 	@mkdir -p "$(@D)"
 	go list -f "--proto_path={{if .Dir}}{{ .Path }}={{ .Dir }}{{end}}" -m all > "$@"


### PR DESCRIPTION
In  `v1` branch the Golang module pre-download exists (https://github.com/make-files/pkg-protobuf/blob/v1/Makefile#L66) to first download the golang modules so that the protobuf imports can be successfully resolved during the file generation process.

This change adds the identical Golang module pre-download command to `v2` to avoid the import errors.