### PR TITLE
added install-protoc command from lib-gha to pkg-protobuf(v1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PROTO_INCLUDE_PATHS ?=
 
 # PROTOC_COMMAND is the path to the protoc command, if this is not specified
 # the latest version of protoc is installed for the host operating system.
-PROTOC_COMMAND ?= $(MF_PROJECT_ROOT)/artifacts/protoc/bin/protoc
+PROTOC_COMMAND ?= $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc
 
 ################################################################################
 
@@ -64,8 +64,8 @@ PROTOC_COMMAND ?= $(MF_PROJECT_ROOT)/artifacts/protoc/bin/protoc
 		$(addprefix --proto_path=,$(PROTO_INCLUDE_PATHS)) \
 		"$(MF_PROJECT_ROOT)/$(@D)"/*.proto
 
-artifacts/protoc/bin/protoc:
-	$(MF_ROOT)/pkg/protobuf/v1/bin/install-protoc "$(MF_PROJECT_ROOT)/artifacts/protoc"
+artifacts/protobuf/bin/protoc:
+	$(MF_ROOT)/pkg/protobuf/v1/bin/install-protoc "$(MF_PROJECT_ROOT)/artifacts/protobuf"
 
 artifacts/protobuf/bin/protoc-gen-go: go.mod
 	$(MF_ROOT)/pkg/protobuf/v1/bin/install-protoc-gen-go "$(MF_PROJECT_ROOT)/$(@D)"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ PROTO_FILES += $(shell PATH="$(PATH)" git-find '*.proto')
 # via the 'artifacts/protobuf/go.proto_paths' file.
 PROTO_INCLUDE_PATHS ?=
 
+# PROTOC_COMMAND is the path to the protoc command, if this is not specified
+# the latest version of protoc is installed for the host operating system.
+PROTOC_COMMAND ?= $(MF_PROJECT_ROOT)/artifacts/protoc/bin/protoc
+
 ################################################################################
 
 # This Makefile provides the recipes used to build each language's source files
@@ -51,13 +55,17 @@ PROTO_INCLUDE_PATHS ?=
 #
 # NOTE: The $$(cat ...) syntax can NOT be swapped to $$(< ...). For reasons
 # unknown this syntax does NOT work under Travis CI.
-%.pb.go: %.proto artifacts/protobuf/bin/protoc-gen-go artifacts/protobuf/go.proto_paths
-	PATH="$(MF_PROJECT_ROOT)/artifacts/protobuf/bin:$$PATH" protoc \
+%.pb.go: %.proto $(PROTOC_COMMAND) artifacts/protobuf/bin/protoc-gen-go artifacts/protobuf/go.proto_paths
+	PATH="$(MF_PROJECT_ROOT)/artifacts/protobuf/bin:$$PATH" $(PROTOC_COMMAND) \
+		--proto_path="$(dir $(PROTOC_COMMAND))../include" \
 		--go_out=plugins=grpc:. \
 		--go_opt=module=$$(go list -m) \
 		$$(cat artifacts/protobuf/go.proto_paths) \
 		$(addprefix --proto_path=,$(PROTO_INCLUDE_PATHS)) \
 		"$(MF_PROJECT_ROOT)/$(@D)"/*.proto
+
+artifacts/protoc/bin/protoc:
+	$(MF_ROOT)/pkg/protobuf/v1/bin/install-protoc "$(MF_PROJECT_ROOT)/artifacts/protoc"
 
 artifacts/protobuf/bin/protoc-gen-go: go.mod
 	$(MF_ROOT)/pkg/protobuf/v1/bin/install-protoc-gen-go "$(MF_PROJECT_ROOT)/$(@D)"

--- a/bin/install-protoc
+++ b/bin/install-protoc
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROTOC_ROOT="${1}"
+shift
+
+case "$(uname -s)" in
+    "Darwin")
+        OS="osx";;
+    "Linux")
+        OS="linux";;
+    *)
+        OS="linux";;
+esac
+
+VERSION="$(curl --head --silent https://github.com/protocolbuffers/protobuf/releases/latest | grep -i '^Location:' | egrep -o '[0-9]+.[0-9]+.[0-9]+')"
+
+if [[ -f "${PROTOC_ROOT}/bin/protoc" ]]; then
+    LOCAL_VERSION="$(${PROTOC_ROOT}/bin/protoc --version | sed -e 's/.* //')"
+    [[ "${VERSION}" == "${LOCAL_VERSION}" ]] && exit 0
+fi
+
+ARCHIVE="protoc-${VERSION}-${OS}-$(uname -m).zip"
+URL="https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/${ARCHIVE}"
+
+mkdir -p "${PROTOC_ROOT}"
+pushd "${PROTOC_ROOT}"
+curl --location --silent --output "${ARCHIVE}" "${URL}"
+unzip -o "${ARCHIVE}"
+chmod +x bin/protoc
+find include/google -type d -exec chmod 755 {} \;
+find include/google -type f -exec chmod 644 {} \;
+popd


### PR DESCRIPTION
Replaces make-files/lib-gha#1, adds installing an artefact of the latest protoc binary (unless overridden by specifying your own `PROTOC_COMMAND`).

Although in testing, I didn't seem to need this line, but I'll test further:
```Makefile
--proto_path="$(dir $(PROTOC_COMMAND))../include" \
```