### PR TITLE
Fix the path for the install-protoc script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ PROTOC_COMMAND ?= $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc
 		$(MF_PROJECT_ROOT)/$(@D)/*.proto
 
 $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc:
-	$(MF_ROOT)/pkg/protobuf/v1/bin/install-protoc "$(MF_PROJECT_ROOT)/artifacts/protobuf"
+	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc "$(MF_PROJECT_ROOT)/artifacts/protobuf"
 
 artifacts/protobuf/bin/go.mod: go.mod
 	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc-gen-go "$(MF_PROJECT_ROOT)/$(@D)"


### PR DESCRIPTION
This PR fixes the path of the `$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc` script in `$(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc` Makefile target.